### PR TITLE
fix: post list page number

### DIFF
--- a/pages/category/[categoryTitle].js
+++ b/pages/category/[categoryTitle].js
@@ -422,9 +422,9 @@ const PostList = ({ categoryInfo, initialTotalCount, pinPostInfo }) => {
           placeholder={`1-${totalPages}`}
           size="small"
           id="outlined-basic"
-          label="Number"
-          variant="outlined"
+          label="Page"
           type="number"
+          defaultValue={1}
           onChange={handleInputCurrentPage}
           InputProps={{
             endAdornment: (


### PR DESCRIPTION
In macOS Chrome: 
![image](https://user-images.githubusercontent.com/61730243/158320850-3cf5ae1f-f297-44c9-b969-8f43e2aa45b2.png)
In macOs Safari: 
![image](https://user-images.githubusercontent.com/61730243/158320940-10e6d264-7410-4630-a6ff-5ffaa3bb5204.png)
