### PR TITLE
refactor: cancel pre-rendering of category pages and admin page

### DIFF
--- a/components/Post/PinPostCard.js
+++ b/components/Post/PinPostCard.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import NextLink from 'next/link';
-import parse from 'html-react-parser';
 import { Chip, Card, Typography, Link } from '@mui/material';
 import { updatePostViewCount } from '../../services/Public';
 
@@ -33,11 +32,13 @@ const PinPostCard = (props) => {
           </Typography>
         </Link>
       </NextLink>
-      <Typography color="inherit" sx={{ mt: 1 }} variant="subtitle2">
-        {context.length > 200
-          ? `${context.substring(0, 200)}...`
-          : parse(context)}
-      </Typography>
+      {context && (
+        <Typography color="inherit" sx={{ mt: 1 }} variant="subtitle2">
+          {context.length > 200
+            ? `${context.replace(/<.*?>| [</].*?>/gi, '').substring(0, 200)}...`
+            : context.replace(/<.*?>| [</].*?>/gi, '')}
+        </Typography>
+      )}
     </Card>
   );
 };

--- a/contexts/UsersRoleContext.js
+++ b/contexts/UsersRoleContext.js
@@ -1,0 +1,60 @@
+import React, { createContext, useContext, useState, useMemo } from 'react';
+
+const UsersRoleContext = createContext([]);
+
+export const UsersRoleContextProvider = ({ children }) => {
+  const [usersToSubmit, setUsersToSubmit] = useState([]);
+
+  const findInstanceByUserId = (user, userList) => {
+    const targetUserInList = userList.find((item) => item.id === user.id);
+    return targetUserInList !== undefined;
+  };
+
+  const addUsersToSubmit = (updatedUsers) => {
+    setUsersToSubmit((prevData) => {
+      const filteredUpdateUsers = updatedUsers.filter((updatedUser) => {
+        if (findInstanceByUserId(updatedUser, prevData)) {
+          return false;
+        }
+        return true;
+      });
+      return [...prevData, ...filteredUpdateUsers];
+    });
+  };
+
+  const deleteUserToSubmit = (cancelledUser) => {
+    setUsersToSubmit((prevData) =>
+      prevData.filter((userToSubmit) => userToSubmit.id !== cancelledUser.id),
+    );
+  };
+
+  const deleteUsersToSubmit = (cancelledUsers) => {
+    const newUsersToSubmit = usersToSubmit.filter(
+      (userToSubmit) => !findInstanceByUserId(userToSubmit, cancelledUsers),
+    );
+    setUsersToSubmit(newUsersToSubmit);
+  };
+
+  const value = useMemo(
+    () => ({
+      usersToSubmit,
+      setUsersToSubmit,
+      addUsersToSubmit,
+      deleteUserToSubmit,
+      deleteUsersToSubmit,
+      findInstanceByUserId,
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [usersToSubmit],
+  );
+
+  return (
+    <UsersRoleContext.Provider value={value}>
+      {children}
+    </UsersRoleContext.Provider>
+  );
+};
+
+export const useUsersRoleContext = () => {
+  return useContext(UsersRoleContext);
+};

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -1,11 +1,13 @@
 import * as React from 'react';
 import Head from 'next/head';
 import { Box, Typography, Tabs, Tab, Divider } from '@mui/material';
+import { useState, useEffect } from 'react';
 import { AdminUser } from '../components/Admin/AdminUser';
 import { getAllUsers } from '../services/Public';
 import MyTime from '../utils/myTime';
 import { UsersRoleContextProvider } from '../components/Admin/UsersRoleContext';
 import Categories from '../components/CategoryManager/categoryTable/Categories';
+import Loading from '../components/Loading/Loading';
 
 const tabs = [
   { label: 'Users', value: 'users' },
@@ -13,29 +15,33 @@ const tabs = [
   { label: 'Roles', value: 'roles' },
 ];
 
-export const getServerSideProps = async () => {
-  const { data: responseAllUsersInfo } = await getAllUsers();
-  const users = responseAllUsersInfo.map((protoUserInfo) => {
-    const user = {
-      id: protoUserInfo.id,
-      logintime: MyTime(protoUserInfo.lastLoginTimestamp),
-      avatarUrl: protoUserInfo.headImgUrl,
-      createdAt: MyTime(protoUserInfo.createTimestamp),
-      email: protoUserInfo.email,
-      name: protoUserInfo.username,
-      role: protoUserInfo.role.roleName,
-    };
-    return user;
-  });
-  return { props: { users } };
-};
-
-const Admin = ({ users }) => {
+const Admin = () => {
   const [currentTab, setCurrentTab] = React.useState('users');
+  const [users, setUsers] = useState();
 
   const handleTabsChange = (event, value) => {
     setCurrentTab(value);
   };
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      const { data: responseAllUsersInfo } = await getAllUsers();
+      const allUsers = responseAllUsersInfo.map((protoUserInfo) => {
+        const user = {
+          id: protoUserInfo.id,
+          logintime: MyTime(protoUserInfo.lastLoginTimestamp),
+          avatarUrl: protoUserInfo.headImgUrl,
+          createdAt: MyTime(protoUserInfo.createTimestamp),
+          email: protoUserInfo.email,
+          name: protoUserInfo.username,
+          role: protoUserInfo.role.roleName,
+        };
+        return user;
+      });
+      setUsers(allUsers);
+    };
+    fetchUsers();
+  });
 
   return (
     <UsersRoleContextProvider>
@@ -63,7 +69,8 @@ const Admin = ({ users }) => {
           ))}
         </Tabs>
         <Divider sx={{ mb: 3 }} />
-        {currentTab === 'users' && <AdminUser allUsers={users} />}
+        {currentTab === 'users' && users && <AdminUser allUsers={users} />}
+        {currentTab === 'users' && !users && <Loading />}
         {currentTab === 'categories' && <Categories />}
         {currentTab === 'roles' && <div>roles</div>}
       </Box>


### PR DESCRIPTION
* Now admin page is completely CSR, category pages' ISR is only for rejecting wrong category path and revalidating new category path.
* Fixed bugs of saving /getting localStorage post display settings
* PinPosts can correctly show and disappear now. (UI seems unbearably ugly)