### PR TITLE
fix: admin page keeps the same layout on refreshing

### DIFF
--- a/components/Layout/three-columns.js
+++ b/components/Layout/three-columns.js
@@ -45,7 +45,6 @@ const ThreeColumns = ({ children }) => {
           style={{
             backgroundColor: 'white',
             borderRadius: '15px',
-            marginTop: '5px',
             marginLeft: '15px',
             padding: '10px',
             height: '85vh',

--- a/pages/admin.js
+++ b/pages/admin.js
@@ -9,7 +9,6 @@ import { getAllUsers } from '../services/Users';
 import MyTime from '../utils/myTime';
 import CommonContainer from '../components/Layout/common-container';
 import Categories from '../components/CategoryManager/categoryTable/Categories';
-import Loading from '../components/Loading/Loading';
 import SetFooter from '../components/Footer/SetFooter.tsx';
 import Role from '../components/Role';
 import checkPermission from '../utils/checkPermission';
@@ -61,17 +60,12 @@ const Admin = () => {
     }
   }, [checkAuth, myDetail]);
 
-  if (!myDetail) {
-    return <Loading />;
-  }
-
   return (
     <CommonContainer>
       <Head>
         <title>Admin | ThinkMore Forum</title>
       </Head>
-
-      <Box>
+      <Box className="FixDirectionTrial">
         <Typography variant="h4">Admin</Typography>
         <Tabs
           indicatorColor="primary"
@@ -93,7 +87,6 @@ const Admin = () => {
         </Tabs>
         <Divider sx={{ mb: 3 }} />
         {currentTab === 'users' && users && <AdminUser allUsers={users} />}
-        {currentTab === 'users' && !users && <Loading />}
         {currentTab === 'categories' && <Categories />}
         {currentTab === 'roles' && <Role />}
         {currentTab === 'footer' && <SetFooter />}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

Thanks again!
-->

### Why:

Issue link: []

<!--
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. If you made changes to the `content` directory, a table will populate in a comment below with the staging and live article links -->
